### PR TITLE
Add ARMv7 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64,linux/arm64,linux/riscv64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/riscv64
           push: true
           tags: ${{ env.TAGS }}
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
 	mkdir -p /etc/pacman.d && \
 	cp /files/mirrorlist-$TARGETARCH /etc/pacman.d/mirrorlist && \
 	BOOTSTRAP_EXTRA_PACKAGES="" && \
-	if [[ "$TARGETARCH" == "arm64" ]]; then \
+	if [[ "$TARGETARCH" == "arm*" ]]; then \
 			curl -L https://github.com/archlinuxarm/archlinuxarm-keyring/archive/8af9b54e9ee0a8f45ab0810e1b33d7c351b32362.zip | unzip -d /tmp/archlinuxarm-keyring - && \
 			mkdir /usr/share/pacman/keyrings && \
 			mv /tmp/archlinuxarm-keyring/*/archlinuxarm* /usr/share/pacman/keyrings/ && \

--- a/files/mirrorlist-arm
+++ b/files/mirrorlist-arm
@@ -1,0 +1,1 @@
+Server = http://mirror.archlinuxarm.org/armv7h/$repo

--- a/files/repos-arm
+++ b/files/repos-arm
@@ -1,0 +1,14 @@
+[core]
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Include = /etc/pacman.d/mirrorlist
+
+[community]
+Include = /etc/pacman.d/mirrorlist
+
+[alarm]
+Include = /etc/pacman.d/mirrorlist
+
+[aur]
+Include = /etc/pacman.d/mirrorlist


### PR DESCRIPTION
Adds support for ARMv7 so that the image can be used on (for example) RPi 2/3.

You can see that it works correctly in [this workflow](https://github.com/ogarcia/docker-archlinuxarm/actions/runs/4616222143/jobs/8160960380), there is a crash at the end when it goes to upload the image to ghcr.io, but that's normal since the repository doesn't match.

In the `mirrorlist-arm` file you will see that the architecture is forced. This is because if you leave it as `$arch` it replaces it with `armv7` instead of `armv7h` and does not find the directory in the repository.